### PR TITLE
Replace ng-bind-html

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "angular": "1.3.x",
-    "angular-sanitize": "1.3.x"
+    "angular-sanitize": "1.3.x",
+    "ng-html-compile": "~1.0.0"
   }
 }

--- a/waterfall.js
+++ b/waterfall.js
@@ -1,4 +1,4 @@
-angular.module('waterfall', ['ngSanitize'])
+angular.module('waterfall', ['ngSanitize', 'ngHtmlCompile'])
 
 .factory('waterfall', function(){
 	'use strict';
@@ -176,7 +176,7 @@ angular.module('waterfall', ['ngSanitize'])
 			+'				<div ng-attr-style="\n'
 			+'					width: {{options.node.width}}px;\n'
 			+'					height: {{options.node.height}}px;\n'
-			+'				" ng-bind-html="node.html"></div>\n'
+			+'				" ng-html-compile="node.html"></div>\n'
 			+'			</foreignObject>\n'
 			+'		</g>\n'
 			+'		<path\n'


### PR DESCRIPTION
Replace ng-bind-html with ng-html-compile , adds more flexibility to use directives as a part of a node's html rendered.
